### PR TITLE
Fix: migration error

### DIFF
--- a/db/migrate/20240429143843_create_user_services.rb
+++ b/db/migrate/20240429143843_create_user_services.rb
@@ -1,8 +1,8 @@
 class CreateUserServices < ActiveRecord::Migration[7.1]
   def change
     create_table :user_services do |t|
-      t.references :user_id, null: false, foreign_key: true
-      t.references :service_id, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :service, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_142050) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_29_143843) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_142050) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_services", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "service_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["service_id"], name: "index_user_services_on_service_id"
+    t.index ["user_id"], name: "index_user_services_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -66,4 +75,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_29_142050) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "user_services", "services"
+  add_foreign_key "user_services", "users"
 end


### PR DESCRIPTION
When using `t.references`, no need to reference the foreign id column, just the table itself, rails is magic